### PR TITLE
Add a compass detection to call sass with the appropriate parameter

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack.pm
+++ b/lib/Mojolicious/Plugin/AssetPack.pm
@@ -85,7 +85,7 @@ convert your less/sass/coffee files each time their asset directive is expanded
 =head2 Preprocessors
 
 This library tries to find default preprocessors for less, scss, js, coffee
-and css.
+and css. It tries to deal with associated libraries such as compass as well.
 
 NOTE! The preprocessors require optional dependencies to function properly.
 Check out L<Mojolicious::Plugin::AssetPack::Preprocessors/detect> for more

--- a/lib/Mojolicious/Plugin/AssetPack/Preprocessors.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Preprocessors.pm
@@ -97,7 +97,27 @@ sub detect {
     $self->add(scss => sub {
       my($assetpack, $text, $file) = @_;
       my $include_dir = dirname $file;
-      run3([$app, '-I', $include_dir, '--stdin', '--scss', $assetpack->minify ? ('-t', 'compressed') : ()], $text, $text);
+      my $err;
+      if (grep("compass",$text))
+      {
+        $assetpack->{log}->warn("compass detected!!!!!");
+        if(which('compass')) 
+        {
+          run3([$app,$assetpack->minify ? ('-t', 'compressed') : (),'--stdin','--scss','--compass',], $text, $text,\$err);
+          if ($err) {
+            $assetpack->{log}->warn("Error processing $file: $err");
+          }
+        }else
+        {
+          $assetpack->{log}->info("Error: import of compass modules in $file while the compass command is not found."); 
+        }
+      }else
+      {
+        run3([$app, '-I', $include_dir, '--stdin', '--scss', $assetpack->minify ? ('-t', 'compressed') : ()], $text, $text,\$err);
+        if ($err) {
+          $assetpack->{log}->warn("Error processing $file: $err");
+        }
+      } 
     });
   }
   if(my $app = which('coffee')) {


### PR DESCRIPTION
When sass files contain compass imports the sass preprocessor need to be called with the --compass parameter.
