### PR TITLE
Added support for "*.sass" Sass files in addition to "*.scss"

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Preprocessors.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Preprocessors.pm
@@ -50,7 +50,7 @@ Installation on Ubuntu and Debian:
 
 Sass makes CSS fun again. Sass is an extension of CSS3, adding nested rules,
 variables, mixins, selector inheritance, and more. See L<http://sass-lang.com>
-for more information.
+for more information. Supports both F<*.scss> and F<*.sass> syntax variants.
 
 Installation on Ubuntu and Debian:
 
@@ -98,6 +98,11 @@ sub detect {
       my($assetpack, $text, $file) = @_;
       my $include_dir = dirname $file;
       run3([$app, '-I', $include_dir, '--stdin', '--scss', $assetpack->minify ? ('-t', 'compressed') : ()], $text, $text);
+    });
+    $self->add(sass => sub {
+      my($assetpack, $text, $file) = @_;
+      my $include_dir = dirname $file;
+      run3([$app, '-I', $include_dir, '--stdin', $assetpack->minify ? ('-t', 'compressed') : ()], $text, $text);
     });
   }
   if(my $app = which('coffee')) {

--- a/t/apps.t
+++ b/t/apps.t
@@ -29,9 +29,11 @@ my $assetpack;
   my $bin = qx{which sass};
   if($bin =~ /\w/) {
     ok $assetpack->preprocessors->has_subscribers('scss'), 'found preprocessor for scss';
+    ok $assetpack->preprocessors->has_subscribers('sass'), 'found preprocessor for sass';
   }
   else {
     ok !$assetpack->preprocessors->has_subscribers('scss'), 'did not find preprocessor for scss';
+    ok !$assetpack->preprocessors->has_subscribers('sass'), 'did not find preprocessor for sass';
   }
 }
 


### PR DESCRIPTION
Hello,

Sass has both a `*.scss` and a `*.sass` syntax variant, with AssertPack so far only supporting the former. As the `sass` preprocessor handles both, support for the `*.sass` variant can be added trivially, which I have done.  It would be nice if this could be included in the mainline.

Cheers,

Marco
