### PR TITLE
Add fallback mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Mojolicious-Plugin-AssetPack
 
+0.33
+       * Can fallback to existing assets in production mode
+
 0.32     Thu Dec 18 12:23:58 2014
        * Add logging of JavaScript code to console on error
        * Able to pass on attrs to script/link tag generator #33

--- a/t/fallback.t
+++ b/t/fallback.t
@@ -3,13 +3,13 @@ use t::Helper;
 use File::Spec::Functions 'catfile';
 use Mojo::Util 'spurt';
 
-my $t = t::Helper->t({});
+my $app = t::Helper->t({})->app;
 
-eval { $t->app->asset('fallback-not-found.js' => '/js/not-found.js'); };
-like $@, qr{could not find already packed asset file}, 'fallback-not-found.js';
+eval { $app->app->asset('fallback-not-found.js' => '/js/not-found.js'); };
+like $@, qr{could not find already packed asset}, 'fallback-not-found.js';
 
 spurt "function fallback(){}\n", catfile qw( t public packed fallback-12345678901234567890123456789012.js );
-eval { $t->app->asset('fallback.js' => '/js/not-found.js') };
+eval { $app->app->asset('fallback.js' => '/js/not-found.js') };
 ok !$@, 'fallback.js' or diag $@;
 
 done_testing;

--- a/t/fallback.t
+++ b/t/fallback.t
@@ -1,0 +1,15 @@
+BEGIN { $ENV{MOJO_MODE} //= 'production' }
+use t::Helper;
+use File::Spec::Functions 'catfile';
+use Mojo::Util 'spurt';
+
+my $t = t::Helper->t({});
+
+eval { $t->app->asset('fallback-not-found.js' => '/js/not-found.js'); };
+like $@, qr{could not find already packed asset file}, 'fallback-not-found.js';
+
+spurt "function fallback(){}\n", catfile qw( t public packed fallback-12345678901234567890123456789012.js );
+eval { $t->app->asset('fallback.js' => '/js/not-found.js') };
+ok !$@, 'fallback.js' or diag $@;
+
+done_testing;


### PR DESCRIPTION
Setting this AssetPack in fallback mode will enable the ```asset()``` helper to use bundled assets if the ```process()``` step fail. L```asset()``` will still throw an error if there are no bundled assets available.
