### PR TITLE
Make error visible regardless of page scroll position

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack.pm
+++ b/lib/Mojolicious/Plugin/AssetPack.pm
@@ -221,7 +221,7 @@ sub _make_error_asset {
     $err =~ s!\n!\\A!g;
     $err =~ s!\s! !g;
     return
-      qq(html:before{background:#f00;color:#fff;font-size:14pt;position:absolute;padding:20px;z-index:9999;content:"$err";});
+      qq(html:before{background:#f00;color:#fff;font-size:14pt;position:fixed;padding:20px;z-index:9999;content:"$err";});
   }
 }
 


### PR DESCRIPTION
This way the user will see the error even if they are working in the middle of the page (unless you do a hard refresh, the scroll position doesn't change on refresh, so errors get missed).