### PR TITLE
Account for SASS_PATH env var when checksumming

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Preprocessor/Scss.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Preprocessor/Scss.pm
@@ -103,7 +103,7 @@ sub checksum {
   while ($$text =~ /$re/gs) {
     my @rel  = split '/', $2;
     my $file = pop @rel;
-    my $path = $self->_file(File::Spec->catdir($dir, @rel), $file, $ext) or next;
+    my $path = $self->_file( $dir, \@rel, $file, $ext) or next;
     $self->{checked}{$path}++ and next;
     push @checksum, $self->checksum(\slurp($path), $path);
   }
@@ -112,10 +112,15 @@ sub checksum {
 }
 
 sub _file {
-  my ($self, $dir, $name, $ext) = @_;
+  my ($self, $dir, $rel, $name, $ext) = @_;
+
   my $path;
-  return $path if -r ($path = catfile $dir, "$name.$ext");
-  return $path if -r ($path = catfile $dir, "_$name.$ext");
+  my @dirs = map File::Spec->catdir($_, @$rel),
+                  split(/:/, $ENV{SASS_PATH}||''), $dir;
+  for ( @dirs ) {
+    return $path if -r ($path = catfile $_, "$name.$ext");
+    return $path if -r ($path = catfile $_, "_$name.$ext");
+  }
   return;
 }
 

--- a/t/public/sass/anotherdir/subdir/_issue-60.scss
+++ b/t/public/sass/anotherdir/subdir/_issue-60.scss
@@ -1,0 +1,2 @@
+// should also be detected when changed
+body{color: #bbb;}

--- a/t/public/sass/issue-60.scss
+++ b/t/public/sass/issue-60.scss
@@ -1,0 +1,1 @@
+@import "subdir/issue-60";

--- a/t/public/sass/subdir/_issue-60.scss
+++ b/t/public/sass/subdir/_issue-60.scss
@@ -1,0 +1,2 @@
+// this file should NOT be loaded
+body{color: #111;}

--- a/t/scss.t
+++ b/t/scss.t
@@ -61,6 +61,36 @@ is(Mojolicious::Plugin::AssetPack::Preprocessor::Scss->_url, 'http://sass-lang.c
   spurt $scss => $scss_file;
 }
 
+{
+  # https://github.com/jhthorsen/mojolicious-plugin-assetpack/pull/60
+
+  local $ENV{SASS_PATH} = File::Spec->catdir(
+    File::Spec->rel2abs( File::Spec->curdir ),
+    qw( t public sass anotherdir)
+  );
+
+  my $scss_file = File::Spec->catfile(
+    qw( t public sass anotherdir subdir _issue-60.scss )
+  );
+  my ($app, $scss);
+
+  $app = t::Helper->t->app;
+  $app->asset('change.css' => '/sass/issue-60.scss');
+  like + ($app->asset->get('change.css', {assets => 1}))[0]->slurp, qr{\#bbb}, 'original';
+
+  use Mojo::Util qw( slurp spurt );
+  $scss = slurp $scss_file;
+  $scss =~ s!bbb!ccc!;
+  spurt $scss => $scss_file;
+
+  $app = t::Helper->t->app;
+  $app->asset('change.css' => '/sass/issue-60.scss');
+  like + ($app->asset->get('change.css', {assets => 1}))[0]->slurp, qr{\#ccc}, 'updated';
+
+  $scss =~ s!ccc!bbb!;
+  spurt $scss => $scss_file;
+}
+
 done_testing;
 
 __DATA__


### PR DESCRIPTION
This pull fixes the issue that when `SASS_PATH` is set, the plugin doesn't check all of its directories. The result is if there are two same-named files in different directories and the file in a directory that should be checked first is changed, the plugin doesn't re-pack the asset because it fails to detect that change.

This is a relevant IRC conversation: http://irclog.perlgeek.de/mojo/2015-08-22#i_11100537