### PR TITLE
Adds sass_functions attribute which will be passed through to CSS::Sass

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Preprocessor/Scss.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Preprocessor/Scss.pm
@@ -110,8 +110,8 @@ Holds optional paths to search for where to find C<@import> files.
 
 =head2 sass_functions
 
-  $self = $self->sass_functions( { 'foo($arg)' => sub { $_[0] } } );
-  $paths = $self->sass_functions;
+  $self->sass_functions( { 'foo($arg)' => sub { $_[0] } } );
+  $functions = $self->sass_functions;
 
 Holds optional functions for libsass's use. Must use L<CSS::Sass> 
 

--- a/lib/Mojolicious/Plugin/AssetPack/Preprocessor/Scss.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Preprocessor/Scss.pm
@@ -50,6 +50,12 @@ The final list of directories to search will be:
   3. $self->include_paths()
   2. split /:/, $ENV{SASS_PATH}
 
+=head2 sass_functions
+
+It possible to set the L</sass_functions> attribute to L<CSS::Sass>:
+
+  $app->asset->preprocessors->add(scss => Scss => {sass_functions=> [...]});
+
 =head2 COMPASS
 
 Compass is an open-source CSS Authoring Framework built on top of L</sass>.
@@ -102,10 +108,18 @@ Holds the path to the "sass" executable. Default to just "sass".
 
 Holds optional paths to search for where to find C<@import> files.
 
+=head2 sass_functions
+
+  $self = $self->sass_functions( { 'foo($arg)' => sub { $_[0] } } );
+  $paths = $self->sass_functions;
+
+Holds optional functions for libsass's use. Must use L<CSS::Sass> 
+
 =cut
 
 has executable => sub { File::Which::which('sass') || 'sass' };
 has include_paths => sub { [] };
+has sass_functions => sub { {} };
 
 =head1 METHODS
 
@@ -161,7 +175,7 @@ sub process {
 
   if (LIBSASS_BINDINGS) {
     local $ENV{SASS_PATH} = '';
-    my %args = (include_paths => [@include_paths]);
+    my %args = (include_paths => [@include_paths], sass_functions => $self->sass_functions);
     $args{output_style} = CSS::Sass::SASS_STYLE_COMPRESSED() if $assetpack->minify;
     $$text = CSS::Sass::sass2scss($$text) if $self->_extension eq 'sass';
     ($$text, $err, my $srcmap) = CSS::Sass::sass_compile($$text, %args);

--- a/t/public/css/c.scss
+++ b/t/public/css/c.scss
@@ -1,0 +1,4 @@
+body {
+  background: #fff image-url('img.png') top left;
+}
+


### PR DESCRIPTION
CSS::Sass can take a sass_functions option which enables the user to
write perl functions that can be called from inside their sass. This
patch allows the user to set sass_functions in the say way that they can
set include_paths. This is only useful when the CSS::Sass library is
used to compile to css.