### PR TITLE
Minor fix to deal with multiple imports of the same Sass file

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
@@ -78,7 +78,7 @@ SEARCH:
 
     for (@basename) {
       my $path = join '/', @rel, $_;
-      $self->{checksum_for_file}{$path}++ and next;
+      $self->{checksum_for_file}{$path}++ and next SEARCH;
       my $imported = $store->asset($path, $paths) or next;
 
       if ($imported->path) {

--- a/t/assets/sass/sass-2-dup.scss
+++ b/t/assets/sass/sass-2-dup.scss
@@ -1,0 +1,7 @@
+@import "sass-2-dup/mixins";
+@import "sass-2-dup/mixins";
+
+div.test {
+  @extend .tester;
+  font-size: large;
+}

--- a/t/assets/sass/sass-2-dup/_mixins.scss
+++ b/t/assets/sass/sass-2-dup/_mixins.scss
@@ -1,0 +1,1 @@
+.tester { font-weight: bold; }

--- a/t/sass.t
+++ b/t/sass.t
@@ -40,6 +40,12 @@ $t->get_ok('/')->status_is(200)
 $t->get_ok($t->tx->res->dom->at('link')->{href})->status_is(200)
   ->content_like(qr{footer.*\#aaa.*body.*\#222}s);
 
+# Duplicate @import
+$t = t::Helper->t(pipes => [qw(Sass Css Combine)]);
+ok eval { $t->app->asset->process('dup.css' => 'sass/sass-2-dup.scss') },
+  'sass with duplicate @imports'
+  or diag $@;
+
 done_testing;
 
 __DATA__


### PR DESCRIPTION
There appears to be a bug when a files is @import'ed multiple times.
Don't know why you would want to import a file multiple times, but I ran
into when attempting to compile Bootstrap Sass 3.3.2.