### PR TITLE
Allow intermediate caches to store assets by default

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Store.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Store.pm
@@ -244,7 +244,7 @@ L<Mojolicious::Static> implements the following new ones.
 =head2 default_headers
 
   $hash_ref = $self->default_headers;
-  $self = $self->default_headers({"Cache-Control" => "max-age=31536000"});
+  $self = $self->default_headers({"Cache-Control" => "public, max-age=31536000"});
 
 Used to set default headers used by L</serve_asset>.
 

--- a/lib/Mojolicious/Plugin/AssetPack/Store.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Store.pm
@@ -8,7 +8,7 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag checksum has_ro DEBUG);
 use File::Basename 'dirname';
 use File::Path 'make_path';
 
-has default_headers => sub { +{"Cache-Control" => "max-age=31536000"} };
+has default_headers => sub { +{"Cache-Control" => "public, max-age=31536000"} };
 
 # MOJO_ASSETPACK_DB_FILE is used in tests
 has _file => sub {

--- a/t/css.t
+++ b/t/css.t
@@ -27,7 +27,7 @@ $t->get_ok('/')->status_is(200)
   ->element_exists(qq(link[href="/asset/$asset_checksum/app.css"]));
 
 $t->get_ok($t->tx->res->dom->at('link')->{href})->status_is(200)
-  ->header_is('Cache-Control', 'max-age=31536000')->header_is('Content-Type', 'text/css')
+  ->header_is('Cache-Control', 'public, max-age=31536000')->header_is('Content-Type', 'text/css')
   ->content_like(qr/\.one\{color.*\.two\{color.*.skipped\s\{/s);
 
 Mojo::Util::monkey_patch('CSS::Minifier::XS', minify => sub { die 'Nope!' });


### PR DESCRIPTION
- Adding 'public' to the Cache-Control header allows intermediate caches
  (in particular reverse proxies and caching load-balancers) to store
  the assets.