### PR TITLE
Fix to @import sass dependencies in before/after_process hooks

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Reloader.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Reloader.pm
@@ -11,8 +11,13 @@ has watch => sub { +{} };
 sub before_process {
   my ($self, $assets) = @_;
   $self->input->{$self->topic} = [map { $_->clone } @$assets];
-  $self->watch->{$self->topic}
-    = [map { ($_->path, @{$_->{dependencies} || []}) } @$assets];
+  $self->watch->{$self->topic} = [map { $_->path } @$assets];
+}
+
+sub after_process {
+  my ($self, $assets) = @_;
+  push @{ $self->watch->{$self->topic} },
+    map { (@{$_->{dependencies} || []}) } @$assets;
 }
 
 sub new {

--- a/t/reloader-imports.t
+++ b/t/reloader-imports.t
@@ -1,0 +1,27 @@
+use t::Helper;
+
+my $file   = Mojo::Asset::File->new(path => 't/assets/t-reloader.scss');
+my $import = Mojo::Asset::File->new(path => 't/assets/_t-reloader-import.scss');
+eval { $import->add_chunk("body{color:#000;}\n") }
+  or plan skip_all => "_t-reloader-import.scss: $!";
+eval { $file->add_chunk("\@import 't-reloader-import.scss';\n") }
+  or plan skip_all => "t-reloader.scss: $!";
+
+my $t = t::Helper->t(pipes => [qw(Reloader Sass Css Combine)]);
+my $asset = $t->app->asset->store->asset('t-reloader.scss');
+$t->app->asset->process('app.css' => $asset);
+
+is_deeply(
+  $t->app->asset->pipe('Reloader')->watch,
+  {
+    'app.css' => [
+      map { $t->app->home . "/assets/$_" } "t-reloader.scss", "_t-reloader-import.scss",
+    ]
+  }
+);
+
+done_testing;
+__DATA__
+@@ index.html.ep
+%= asset 'app.css'
+


### PR DESCRIPTION
The new before/after_process hooks are great, but the asset dependencies
haven't been updated when the before_process hook is called. This patch
moves adding dependencies to the watch array, to the after_process hook.
