### PR TITLE
Include `use File::Basename 'dirname';`

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Less.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Less.pm
@@ -1,6 +1,7 @@
 package Mojolicious::Plugin::AssetPack::Pipe::Less;
 use Mojo::Base 'Mojolicious::Plugin::AssetPack::Pipe';
 use Mojolicious::Plugin::AssetPack::Util qw(diag $CWD DEBUG);
+use File::Basename 'dirname';
 
 sub process {
   my ($self, $assets) = @_;


### PR DESCRIPTION
Missing use statement for function call dirname().