### PR TITLE
Replaced assetpack.db with .meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,9 @@
 .sass-cache
 *.old
 *.swp
+.*.meta
 ~$
 /Mojolicious-Plugin-AssetPack*tar.gz
-/public/packed/
-/t/public/packed/
 t/package-lock.json
 node_modules
 .sass-cache

--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Revision history for perl distribution Mojolicious-Plugin-AssetPack
 
+2.06 Not Released
+ - Replaced assetpack.db with .meta files for each topic #137
+ - Removed $asset->FROM_JSON #137
+ - Changed $asset->checksum need to be calculated in the before_process process step #137
+ - Changed $store->load API #137
+ - Changed $store->save API #137
+
 2.05 2018-08-01T14:19:35+0800
  - Fix s///r is not supported in older Perls #136
  - Fix Favicon rendering of manifest and browserconfig

--- a/lib/Mojolicious/Plugin/AssetPack.pm
+++ b/lib/Mojolicious/Plugin/AssetPack.pm
@@ -151,7 +151,6 @@ sub _process {
   $self->_app->log->debug(qq(Processed asset "$topic". [@checksum])) if DEBUG;
   $self->{by_checksum}{$_->checksum} = $_ for @$assets;
   $self->{by_topic}{$topic} = $assets;
-  $self->store->persist;
   $self;
 }
 
@@ -285,16 +284,6 @@ Your application creates and refers to an asset by its topic (virtual asset
 name).  The process of building actual assets from their components is
 delegated to "pipe objects". Please see
 L<Mojolicious::Plugin::AssetPack::Guides::Tutorial/Pipes> for a complete list.
-
-=head1 BREAKING CHANGES
-
-=head2 assetpack.db (v1.47)
-
-C<assetpack.db> no longer track files downloaded from the internet. It will
-mostly "just work", but in some cases version 1.47 might download assets that
-have already been downloaded with AssetPack version 1.46 and earlier.
-
-The goal is to remove C<assetpack.db> completely.
 
 =head1 GUIDES
 

--- a/lib/Mojolicious/Plugin/AssetPack.pm
+++ b/lib/Mojolicious/Plugin/AssetPack.pm
@@ -132,12 +132,14 @@ sub _process {
     $asset->checksum;
   }
 
-  for my $method (qw(before_process process after_process)) {
+  for my $stage (qw(before_process process after_process)) {
+    $assets->map(stage => $stage);
+
     for my $pipe (@{$self->{pipes}}) {
-      next unless $pipe->can($method);
+      next unless $pipe->can($stage);
       local $pipe->{topic} = $topic;
-      diag '%s->%s("%s")', ref $pipe, $method, $topic if DEBUG;
-      $pipe->$method($assets);
+      diag '%s->%s("%s")', ref $pipe, $stage, $topic if DEBUG;
+      $pipe->$stage($assets);
     }
   }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Asset.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Asset.pm
@@ -89,9 +89,8 @@ sub content {
 
 sub path {
   my $self = shift;
-  return $self->_asset(Mojo::Asset::File->new(path => $_[0])) if $_[0];
-  return Mojo::File->new($self->_asset->path) if $self->_asset->isa('Mojo::Asset::File');
-  return undef;
+  return $self->_asset(Mojo::Asset::File->new(path => $_[0])) if @_;
+  return $self->_asset->isa('Mojo::Asset::File') ? Mojo::File->new($self->_asset->path) : undef;
 }
 
 sub size { $_[0]->_asset->size }
@@ -106,14 +105,9 @@ sub _default_tag_for {
   return $c->tag(@template, Mojo::URL->new("$args->{base_url}$url"), @attrs);
 }
 
-sub FROM_JSON {
-  my ($self, $attrs) = @_;
-  $self->$_($attrs->{$_}) for grep { defined $attrs->{$_} } qw(format minified);
-  $self;
-}
-
 sub TO_JSON {
-  return {map { ($_ => $_[0]->$_) } qw(checksum format minified name url)};
+  my $self = shift;
+  return {(map { ($_ => $self->$_) } qw(checksum format minified name url)), @_};
 }
 
 1;
@@ -253,19 +247,6 @@ Returns the size of the asset in bytes.
 
 Returns a L<Mojo::URL> object for this asset. C<$c> need to be a
 L<Mojolicious::Controller>.
-
-=head2 FROM_JSON
-
-  $self = $self->FROM_JSON($hash_ref);
-
-The opposite of L</TO_JSON>. Will set the read/write L</ATTRIBUTES> from the
-values in C<$hash_ref>.
-
-=head2 TO_JSON
-
-  $hash_ref = $self->FROM_JSON;
-
-The opposite of L</FROM_JSON>. Will generate a hash ref from L</ATTRIBUTES>.
 
 =head1 SEE ALSO
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe.pm
@@ -133,21 +133,19 @@ Mojolicious::Plugin::AssetPack::Pipe - Base class for a pipe
         return if $asset->format ne "css";
 
         # Change $attr if this pipe will modify $asset attributes
-        my $attr    = $asset->TO_JSON;
+        my $attrs   = $asset->TO_JSON;
         my $content = $asset->content;
 
         # Private name to load/save meta data under
-        $attr->{key} = "coolpipe";
+        $attrs->{key} = "coolpipe";
 
         # Return asset if already processed
-        if ($content !~ /white/ and $file = $store->load($attr)) {
-          return $asset->content($file);
-        }
+        return if $content !~ /white/ and $store->load($asset, $attrs);
 
         # Process asset content
         diag q(Replace white with red in "%s".), $asset->url if DEBUG;
         $content =~ s!white!red!g;
-        $asset->content($store->save(\$content, $attr))->minified(1);
+        $store->save($asset, \$content, $attrs);
       }
     );
   }

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe.pm
@@ -18,6 +18,8 @@ has_ro 'assetpack';
 
 sub app { shift->assetpack->ua->server->app }
 
+sub process { Carp::confess('Method "process" not implemented by subclass') }
+
 sub run {
   my ($self, $cmd, @args) = @_;
   my $name = path($cmd->[0])->basename;
@@ -31,7 +33,7 @@ sub run {
   };
 }
 
-sub process { Carp::confess('Method "process" not implemented by subclass') }
+sub store { shift->assetpack->store }
 
 sub _find_app {
   my ($self, $apps, $path) = @_;
@@ -222,6 +224,12 @@ See L<IPC::Run3/run3> for details about the arguments. This method will try to
 call C<_install_some_app()> unless "som_app" was found in
 L<PATH|File::Spec/path>. This method could then try to install the application
 and must return the path to the installed application.
+
+=head2 store
+
+  $store = $self->store;
+
+Returns L<Mojolicious::Plugin::AssetPack/store>.
 
 =head1 SEE ALSO
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/CoffeeScript.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/CoffeeScript.pm
@@ -6,17 +6,15 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag $CWD DEBUG);
 sub process {
   my ($self, $assets) = @_;
   my $store = $self->assetpack->store;
-  my $file;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
+    my $attrs = $asset->TO_JSON(format => 'js', key => 'coffee');
     return if $asset->format ne 'coffee';
-    my $attrs = $asset->TO_JSON;
-    @$attrs{qw(format key)} = qw(js coffee);
-    return $asset->content($file)->FROM_JSON($attrs) if $file = $store->load($attrs);
-    diag 'Process "%s" with checksum %s.', $asset->url, $attrs->{checksum} if DEBUG;
+    return if $store->load($asset, $attrs);
+    diag 'Process "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     $self->run([qw(coffee --compile --stdio)], \$asset->content, \my $js);
-    $asset->content($store->save(\$js, $attrs))->FROM_JSON($attrs);
+    $store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/CoffeeScript.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/CoffeeScript.pm
@@ -5,16 +5,15 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag $CWD DEBUG);
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(format => 'js', key => 'coffee');
     return if $asset->format ne 'coffee';
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
     diag 'Process "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     $self->run([qw(coffee --compile --stdio)], \$asset->content, \my $js);
-    $store->save($asset, \$js, $attrs);
+    $self->store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Combine.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Combine.pm
@@ -31,9 +31,15 @@ sub process {
     my $checksum = checksum $combine->map('checksum')->join(':');
     my $content = $combine->map('content')->map(sub { /\n$/ ? $_ : "$_\n" })->join;
     diag 'Combining assets into "%s" with checksum %s.', $self->topic, $checksum if DEBUG;
-    push @$assets,
-      Mojolicious::Plugin::AssetPack::Asset->new(url => $self->topic)->checksum($checksum)->minified(1)
-      ->content($content);
+    push(
+      @$assets,
+      Mojolicious::Plugin::AssetPack::Asset->new(
+        checksum => $checksum,
+        content  => $content,
+        minified => 1,
+        url      => $self->topic,
+      )
+    );
   }
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Css.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Css.pm
@@ -9,7 +9,7 @@ sub process {
   return $assets unless $self->assetpack->minify;
   return $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON(key => 'css-min', minified => 1);
+    my $attrs = $asset->TO_JSON(minified => 1, key => 'min');
     return if $asset->format ne 'css' or $asset->minified;
     return if $self->store->load($asset, $attrs);
     load_module 'CSS::Minifier::XS';

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Css.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Css.pm
@@ -5,18 +5,17 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag load_module DEBUG);
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   return $assets unless $self->assetpack->minify;
   return $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(key => 'css-min', minified => 1);
     return if $asset->format ne 'css' or $asset->minified;
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
     load_module 'CSS::Minifier::XS';
     diag 'Minify "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     my $css = CSS::Minifier::XS::minify($asset->content);
-    $store->save($asset, \$css, $attrs);
+    $self->store->save($asset, \$css, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Css.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Css.pm
@@ -6,20 +6,17 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag load_module DEBUG);
 sub process {
   my ($self, $assets) = @_;
   my $store = $self->assetpack->store;
-  my $file;
 
-  return unless $self->assetpack->minify;
+  return $assets unless $self->assetpack->minify;
   return $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON;
-    $attrs->{key}      = 'css-min';
-    $attrs->{minified} = 1;
+    my $attrs = $asset->TO_JSON(key => 'css-min', minified => 1);
     return if $asset->format ne 'css' or $asset->minified;
-    return $asset->content($file)->minified(1) if $file = $store->load($attrs);
+    return if $store->load($asset, $attrs);
     load_module 'CSS::Minifier::XS';
     diag 'Minify "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     my $css = CSS::Minifier::XS::minify($asset->content);
-    $asset->content($store->save(\$css, $attrs))->minified(1);
+    $store->save($asset, \$css, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Fetch.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Fetch.pm
@@ -26,7 +26,6 @@ our %FORMATS = (
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
   my $route = $self->assetpack->route;
   my %related;
 
@@ -50,7 +49,7 @@ sub process {
 
       unless ($related{$url}) {
         diag "Fetch resource $url" if DEBUG;
-        my $related = $store->asset($url) or die "AssetPack was unable to fetch related asset $url";
+        my $related = $self->store->asset($url) or die "AssetPack was unable to fetch related asset $url";
         $self->assetpack->process($related->name, $related);
         my $path = $route->render($related->TO_JSON);
         $path =~ s!^/!!;

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/JavaScript.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/JavaScript.pm
@@ -6,21 +6,18 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag load_module DEBUG);
 sub process {
   my ($self, $assets) = @_;
   my $store = $self->assetpack->store;
-  my $file;
 
   return unless $self->assetpack->minify;
   return $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON;
-    $attrs->{key}      = 'js-min';
-    $attrs->{minified} = 1;
+    my $attrs = $asset->TO_JSON(minified => 1, key => 'js-min');
     return if $asset->format ne 'js' or $asset->minified;
-    return $asset->content($file)->minified(1) if $file = $store->load($attrs);
-    return unless length(my $js = $asset->content);
+    return if $store->load($asset, $attrs);
+    return if !length(my $js = $asset->content);
     load_module 'JavaScript::Minifier::XS';
     diag 'Minify "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     $js = JavaScript::Minifier::XS::minify($js);
-    $asset->content($store->save(\$js, $attrs))->minified(1);
+    $store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/JavaScript.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/JavaScript.pm
@@ -5,19 +5,18 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag load_module DEBUG);
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   return unless $self->assetpack->minify;
   return $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(minified => 1, key => 'js-min');
     return if $asset->format ne 'js' or $asset->minified;
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
     return if !length(my $js = $asset->content);
     load_module 'JavaScript::Minifier::XS';
     diag 'Minify "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     $js = JavaScript::Minifier::XS::minify($js);
-    $store->save($asset, \$js, $attrs);
+    $self->store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/JavaScript.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/JavaScript.pm
@@ -9,7 +9,7 @@ sub process {
   return unless $self->assetpack->minify;
   return $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON(minified => 1, key => 'js-min');
+    my $attrs = $asset->TO_JSON(minified => 1, key => 'min');
     return if $asset->format ne 'js' or $asset->minified;
     return if $self->store->load($asset, $attrs);
     return if !length(my $js = $asset->content);

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Jpeg.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Jpeg.pm
@@ -15,7 +15,7 @@ sub process {
 
   return $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON(minified => 1, key => sprintf '%s-min', $self->app);
+    my $attrs = $asset->TO_JSON(minified => 1, key => 'min');
     return if $asset->format !~ /^jpe?g$/ or $asset->minified or !$self->assetpack->minify;
     return if $self->store->load($asset, $attrs);
     diag 'Process "%s", with checksum %s.', $asset->url, $asset->checksum if DEBUG;

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Jpeg.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Jpeg.pm
@@ -12,15 +12,14 @@ has app_args => sub {
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   return $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(minified => 1, key => sprintf '%s-min', $self->app);
     return if $asset->format !~ /^jpe?g$/ or $asset->minified or !$self->assetpack->minify;
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
     diag 'Process "%s", with checksum %s.', $asset->url, $asset->checksum if DEBUG;
-    $store->save($asset, $self->_run_app($asset), $attrs);
+    $self->store->save($asset, $self->_run_app($asset), $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Less.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Less.pm
@@ -5,20 +5,19 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag $CWD DEBUG);
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(format => 'css', key => 'less');
     return if $asset->format ne 'less';
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
     diag 'Process "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     my @args = qw(lessc --no-color);
     my $file = $asset->path ? $asset : Mojo::Asset::File->new->add_chunk($asset->content);
     push @args, '--include-path=' . $asset->path->dirname if $asset->path;
     push @args, $file->path;
     $self->run(\@args, undef, \my $css);
-    $store->save($asset, \$css, $attrs);
+    $self->store->save($asset, \$css, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Less.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Less.pm
@@ -6,21 +6,19 @@ use Mojolicious::Plugin::AssetPack::Util qw(diag $CWD DEBUG);
 sub process {
   my ($self, $assets) = @_;
   my $store = $self->assetpack->store;
-  my $file;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
+    my $attrs = $asset->TO_JSON(format => 'css', key => 'less');
     return if $asset->format ne 'less';
-    my $attrs = $asset->TO_JSON;
-    @$attrs{qw(format key)} = qw(css less);
-    return $asset->content($file)->FROM_JSON($attrs) if $file = $store->load($attrs);
-    diag 'Process "%s" with checksum %s.', $asset->url, $attrs->{checksum} if DEBUG;
+    return if $store->load($asset, $attrs);
+    diag 'Process "%s" with checksum %s.', $asset->url, $asset->checksum if DEBUG;
     my @args = qw(lessc --no-color);
     my $file = $asset->path ? $asset : Mojo::Asset::File->new->add_chunk($asset->content);
     push @args, '--include-path=' . $asset->path->dirname if $asset->path;
     push @args, $file->path;
     $self->run(\@args, undef, \my $css);
-    $asset->content($store->save(\$css, $attrs))->FROM_JSON($attrs);
+    $store->save($asset, \$css, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Png.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Png.pm
@@ -13,15 +13,14 @@ has app_args => sub {
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   return $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(minified => 1, key => sprintf '%s-min', $self->app);
     return if $asset->format ne 'png' or $asset->minified or !$self->assetpack->minify;
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
     diag 'Process "%s", with checksum %s.', $asset->url, $asset->checksum if DEBUG;
-    $store->save($asset, $self->_run_app($asset), $attrs);
+    $self->store->save($asset, $self->_run_app($asset), $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Png.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Png.pm
@@ -14,18 +14,14 @@ has app_args => sub {
 sub process {
   my ($self, $assets) = @_;
   my $store = $self->assetpack->store;
-  my $file;
 
   return $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON;
-    $attrs->{key} = sprintf '%s-min', $self->app;
-    $attrs->{minified} = 1;
-    return if $asset->format ne 'png' or $asset->minified;
-    return unless $self->assetpack->minify;
-    return $asset->content($file)->minified(1) if $file = $store->load($attrs);
-    diag 'Process "%s", with checksum %s.', $asset->url, $attrs->{checksum} if DEBUG;
-    $asset->content($store->save($self->_run_app($asset), $attrs))->FROM_JSON($attrs);
+    my $attrs = $asset->TO_JSON(minified => 1, key => sprintf '%s-min', $self->app);
+    return if $asset->format ne 'png' or $asset->minified or !$self->assetpack->minify;
+    return if $store->load($asset, $attrs);
+    diag 'Process "%s", with checksum %s.', $asset->url, $asset->checksum if DEBUG;
+    $store->save($asset, $self->_run_app($asset), $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Png.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Png.pm
@@ -16,7 +16,7 @@ sub process {
 
   return $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON(minified => 1, key => sprintf '%s-min', $self->app);
+    my $attrs = $asset->TO_JSON(minified => 1, key => 'min');
     return if $asset->format ne 'png' or $asset->minified or !$self->assetpack->minify;
     return if $self->store->load($asset, $attrs);
     diag 'Process "%s", with checksum %s.', $asset->url, $asset->checksum if DEBUG;

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Riotjs.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Riotjs.pm
@@ -8,18 +8,17 @@ has _riotjs => sub { [shift->_find_app([qw(nodejs node)]), path(__FILE__)->dirna
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(format => 'js', key => 'riot');
     return if $asset->format ne 'tag';
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
     local $CWD = $self->app->home->to_string;
     local $ENV{NODE_PATH} = $self->app->home->rel_file('node_modules');
     $self->run([qw(riot --version)], undef, \undef) unless $self->{installed}++;
     $self->run($self->_riotjs, \$asset->content, \my $js);
-    $store->save($asset, \$js, $attrs);
+    $self->store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Riotjs.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Riotjs.pm
@@ -9,20 +9,17 @@ has _riotjs => sub { [shift->_find_app([qw(nodejs node)]), path(__FILE__)->dirna
 sub process {
   my ($self, $assets) = @_;
   my $store = $self->assetpack->store;
-  my $file;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON;
-    $attrs->{key}    = 'riot';
-    $attrs->{format} = 'js';
-    return unless $asset->format eq 'tag';
-    return $asset->content($file)->FROM_JSON($attrs) if $file = $store->load($attrs);
+    my $attrs = $asset->TO_JSON(format => 'js', key => 'riot');
+    return if $asset->format ne 'tag';
+    return if $store->load($asset, $attrs);
     local $CWD = $self->app->home->to_string;
     local $ENV{NODE_PATH} = $self->app->home->rel_file('node_modules');
     $self->run([qw(riot --version)], undef, \undef) unless $self->{installed}++;
     $self->run($self->_riotjs, \$asset->content, \my $js);
-    $asset->content($store->save(\$js, $attrs))->FROM_JSON($attrs);
+    $store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/RollupJs.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/RollupJs.pm
@@ -49,7 +49,7 @@ sub process {
 
   $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON(minified => $minify, key => 'rollup');
+    my $attrs = $asset->TO_JSON(minified => $minify, key => $minify ? 'min' : 'rollup');
     return unless $asset->format eq 'js';
     return unless $asset->path and -r $asset->path;
     return unless $asset->content =~ /\bimport\s.*\bfrom\b/s;

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/RollupJs.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/RollupJs.pm
@@ -46,7 +46,6 @@ has _rollupjs => sub {
 sub process {
   my ($self, $assets) = @_;
   my $minify = $self->assetpack->minify;
-  my $store  = $self->assetpack->store;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
@@ -54,7 +53,7 @@ sub process {
     return unless $asset->format eq 'js';
     return unless $asset->path and -r $asset->path;
     return unless $asset->content =~ /\bimport\s.*\bfrom\b/s;
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
 
     local $CWD            = $self->app->home->to_string;
     local $ENV{NODE_ENV}  = $self->app->mode;
@@ -65,7 +64,7 @@ sub process {
 
     $self->_install_node_modules('rollup', @{$self->modules}, @{$self->plugins}) unless $self->{installed}++;
     $self->run([@{$self->_rollupjs}, $asset->path, _module_name($asset->name)], undef, \my $js);
-    $store->save($asset, \$js, $attrs);
+    $self->store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
@@ -48,7 +48,7 @@ sub process {
 
     my ($attrs, $content) = ($asset->TO_JSON(format => 'css'), $asset->content);
     $attrs->{minified} = $self->assetpack->minify;
-    $attrs->{key} = sprintf 'sass%s', $attrs->{minified} ? '-min' : '';
+    $attrs->{key} = $attrs->{minified} ? 'min' : 'sass';
 
     return if $self->store->load($asset, $attrs);
     return if $asset->isa('Mojolicious::Plugin::AssetPack::Asset::Null');

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/TypeScript.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/TypeScript.pm
@@ -13,22 +13,19 @@ has _typescript => sub {
 sub process {
   my ($self, $assets) = @_;
   my $store = $self->assetpack->store;
-  my $file;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
-    my $attrs = $asset->TO_JSON;
-    $attrs->{key}    = 'ts';
-    $attrs->{format} = 'js';
-    return unless $asset->format eq 'ts';
-    return $asset->content($file)->FROM_JSON($attrs) if $file = $store->load($attrs);
+    my $attrs = $asset->TO_JSON(format => 'js', key => 'ts');
+    return if $asset->format ne 'ts';
+    return if $store->load($asset, $attrs);
 
     $self->_install_typescript unless $self->{installed}++;
     local $CWD = $self->app->home->to_string;
     local $ENV{NODE_PATH} = $self->app->home->rel_file('node_modules');
 
     $self->run($self->_typescript, \$asset->content, \my $js);
-    $asset->content($store->save(\$js, $attrs))->FROM_JSON($attrs);
+    $store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/TypeScript.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/TypeScript.pm
@@ -12,20 +12,19 @@ has _typescript => sub {
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   $assets->each(sub {
     my ($asset, $index) = @_;
     my $attrs = $asset->TO_JSON(format => 'js', key => 'ts');
     return if $asset->format ne 'ts';
-    return if $store->load($asset, $attrs);
+    return if $self->store->load($asset, $attrs);
 
     $self->_install_typescript unless $self->{installed}++;
     local $CWD = $self->app->home->to_string;
     local $ENV{NODE_PATH} = $self->app->home->rel_file('node_modules');
 
     $self->run($self->_typescript, \$asset->content, \my $js);
-    $store->save($asset, \$js, $attrs);
+    $self->store->save($asset, \$js, $attrs);
   });
 }
 

--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Vuejs.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Vuejs.pm
@@ -3,7 +3,6 @@ use Mojo::Base 'Mojolicious::Plugin::AssetPack::Pipe';
 
 sub process {
   my ($self, $assets) = @_;
-  my $store = $self->assetpack->store;
 
   return $assets->each(sub {
     my ($asset, $index) = @_;

--- a/lib/Mojolicious/Plugin/AssetPack/Store.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Store.pm
@@ -9,11 +9,6 @@ use Mojolicious::Types;
 use Mojolicious::Plugin::AssetPack::Asset;
 use Mojolicious::Plugin::AssetPack::Util qw(diag checksum has_ro DEBUG);
 
-use constant CACHE_DIR => 'cache';
-
-# MOJO_ASSETPACK_DB_FILE is used in tests
-use constant DB_FILE => $ENV{MOJO_ASSETPACK_DB_FILE} || 'assetpack.db';
-our %DB_KEYS = map { $_ => 1 } qw(checksum format minified rel);
 our %FALLBACK_TEMPLATES = %{data_section(__PACKAGE__)};
 
 for my $name (keys %FALLBACK_TEMPLATES) {
@@ -38,19 +33,6 @@ has _types => sub {
 };
 
 has_ro 'ua';
-
-has_ro _db => sub {
-  my $self = shift;
-  my ($db, $key, $url) = ({});
-  for my $path (reverse map { path($_, DB_FILE) } @{$self->paths}) {
-    open my $DB, '<', $path or next;
-    while (my $line = <$DB>) {
-      ($key, $url) = ($1, $2) if $line =~ /^\[([\w-]+):(.+)\]$/;
-      $db->{$url}{$key}{$1} = $2 if $key and $line =~ /^(\w+)=(.*)/ and $DB_KEYS{$1};
-    }
-  }
-  return $db;
-};
 
 sub asset {
   my ($self, $urls, $paths) = @_;
@@ -87,46 +69,18 @@ sub asset {
 }
 
 sub load {
-  my $self    = shift;
-  my $asset   = UNIVERSAL::isa($_[0], 'Mojolicious::Plugin::AssetPack::Asset') ? shift : undef;
-  my $attrs   = shift;
-  my $db_attr = $self->_db_get($attrs) or return undef;
-  my @rel     = $self->_cache_path($attrs);
-  my $loaded  = $self->asset(join '/', @rel);
+  my $self  = shift;
+  my $asset = UNIVERSAL::isa($_[0], 'Mojolicious::Plugin::AssetPack::Asset') ? shift : undef;
+  my $attrs = shift;
 
-  return undef unless $loaded;
-  return undef unless $db_attr->{checksum} eq $attrs->{checksum};
-  diag 'Load "%s" = 1', $loaded->path || $loaded->url if DEBUG;
-  local $attrs->{content} = $loaded;
+  my $cached = $self->asset(join '/', $self->_cache_path_parts_from_attrs($attrs));
+  return undef unless $cached;
+  return undef if $self->_cached_checksum($cached) and $cached->checksum ne $asset->checksum;
+
+  diag 'Load "%s" = 1 (%s == %s)', $cached->path, $asset->checksum, $cached->checksum || 'unknown' if DEBUG;
+  local $attrs->{content} = $cached;
   map { defined $attrs->{$_} and $asset->$_($attrs->{$_}) } qw(content format minified) if $asset;
   return $asset;
-}
-
-sub persist {
-  my $self    = shift;
-  my $db      = $self->_db;
-  my $path    = path($self->paths->[0], DB_FILE);
-  my @db_keys = sort keys %DB_KEYS;
-  my $DB;
-
-  unless (open $DB, '>', $path) {
-    diag 'Save "%s" = 0 (%s)', $path, $! if DEBUG;
-    return $self;
-  }
-
-  diag 'Save "%s" = 1', $path if DEBUG;
-  for my $url (sort keys %$db) {
-    for my $key (sort keys %{$db->{$url}}) {
-      Carp::confess("Invalid key '$key'. Need to be [a-z-].") unless $key =~ /^[\w-]+$/;
-      printf $DB "[%s:%s]\n", $key, $url;
-      for my $attr (@db_keys) {
-        next unless defined $db->{$url}{$key}{$attr};
-        printf $DB "%s=%s\n", $attr, $db->{$url}{$key}{$attr};
-      }
-    }
-  }
-
-  return $self;
 }
 
 sub save {
@@ -134,16 +88,15 @@ sub save {
   my $asset = UNIVERSAL::isa($_[0], 'Mojolicious::Plugin::AssetPack::Asset') ? shift : $self->asset_class->new;
   my $ref   = shift;
   my $attrs = shift;
-  my $path  = path($self->paths->[0], $self->_cache_path($attrs));
+  my $path  = path($self->paths->[0], $self->_cache_path_parts_from_attrs($attrs));
   my $dir   = $path->dirname;
 
-  # Do not care if this fail. Can fallback to temp files.
-  mkdir $dir if !-d $dir and -w $dir->dirname;
+  mkdir $dir if !-d $dir and -w $dir->dirname;    # Do not care if this fail
   diag 'Save "%s" = %s', $path, -d $dir ? 1 : 0 if DEBUG;
 
   if (-w $dir) {
     $asset->path($path->spurt($$ref));
-    $self->_db_set(%$attrs);
+    $self->_cached_checksum($asset => $asset->checksum);
   }
   else {
     $asset->content($$ref);
@@ -198,7 +151,7 @@ sub serve_fallback_for_assets {
 sub _already_downloaded {
   my ($self, $url) = @_;
   my $asset = $self->asset_class->new(url => "$url");
-  my @dirname = $self->_url2path($url, '');
+  my @dirname = $self->_cache_path_parts_from_url($url, '');
   my $basename = pop @dirname;
 
   for my $path (map { path $_, @dirname } @{$self->paths}) {
@@ -214,6 +167,7 @@ sub _already_downloaded {
     }
   }
 
+  # Could not find cached asset
   return undef;
 }
 
@@ -231,53 +185,58 @@ sub _asset_from_helper {
   $asset;
 }
 
-sub _cache_path {
+sub _cache_path_parts { shift; return cache => @_ }
+
+sub _cache_path_parts_from_attrs {
   my ($self, $attrs) = @_;
-  return (
-    CACHE_DIR, sprintf '%s-%s.%s%s',
-    $attrs->{name},
-    checksum($attrs->{url}),
-    $attrs->{minified} ? 'min.' : '',
-    $attrs->{format}
-  );
+  $self->_cache_path_parts(sprintf '%s-%s.%s.%s', $attrs->{name}, checksum($attrs->{url}), @$attrs{qw(key format)});
 }
 
-sub _db_get {
-  my ($self, $attrs) = @_;
-  my $db = $self->_db;
-  return undef unless my $data = $db->{$attrs->{url}};
-  return undef unless $data = $data->{$attrs->{key}};
-  return {%$attrs, %$data};
+sub _cache_path_parts_from_url {
+  my ($self, $url, $format) = @_;
+  my $query = $url->query->to_string;
+  my @path;
+
+  push @path, $url->host if $url->host;
+  push @path, @{$url->path};
+
+  $query =~ s!\W!_!g;
+  $path[-1] .= "_$query.$format" if $query;
+
+  return $self->_cache_path_parts(@path);
 }
 
-sub _db_set {
-  return if $ENV{MOJO_ASSETPACK_LAZY};
-  my ($self, %attrs) = @_;
-  my ($key,  $url)   = @attrs{qw(key url)};
-  $self->_db->{$url}{$key} = {%attrs};
+sub _cached_checksum {
+  my ($self, $asset, $checksum) = @_;
+  my $path = path $asset->path;
+
+  $path = path $path->dirname, sprintf '.%s.meta', $path->basename;
+
+  return $path->spurt("checksum:$checksum\n") if $checksum;                                               # Write
+  return $asset->stage('before_process')->checksum(($path->slurp =~ /checksum:(\w+)/)[0]) if -r $path;    # Read
+  return undef;
 }
 
 sub _download {
   my ($self, $url) = @_;
   my %attrs = (url => $url->clone);
-  my ($asset, $path);
+  my $path;
 
   if ($attrs{url}->host eq 'local') {
     my $base = $self->ua->server->url;
     $url = $url->clone->scheme($base->scheme)->host_port($base->host_port);
   }
-
-  return $asset if $attrs{url}->host ne 'local' and $asset = $self->_already_downloaded($url);
+  elsif (my $asset = $self->_already_downloaded($url)) {
+    return $asset;
+  }
 
   my $tx = $self->ua->get($url);
-  my $h  = $tx->res->headers;
-
   if (my $err = $tx->error) {
-    $self->_log->warn("[AssetPack] Unable to download $url: $err->{message}");
+    $self->ua->server->app->log->warn("[AssetPack] Unable to download $url: $err->{message}");
     return undef;
   }
 
-  my $ct = $h->content_type || '';
+  my $ct = $tx->res->headers->content_type || '';
   if ($ct ne 'text/plain') {
     $ct =~ s!;.*$!!;
     $attrs{format} = $self->_types->detect($ct)->[0];
@@ -286,8 +245,8 @@ sub _download {
   $attrs{format} ||= $tx->req->url->path->[-1] =~ /\.(\w+)$/ ? $1 : 'bin';
 
   if ($attrs{url}->host ne 'local') {
-    $path = path($self->paths->[0], $self->_url2path($attrs{url}, $attrs{format}));
-    $self->_log->info(qq(Caching "$url" to "$path".));
+    $path = path($self->paths->[0], $self->_cache_path_parts_from_url($attrs{url}, $attrs{format}));
+    $self->ua->server->app->log->info(qq(Caching "$url" to "$path".));
     $path->dirname->make_path unless -d $path->dirname;
     $path->spurt($tx->res->body);
   }
@@ -295,22 +254,6 @@ sub _download {
   $attrs{url} = "$attrs{url}";
   return $self->asset_class->new(%attrs, path => $path) if $path;
   return $self->asset_class->new(%attrs, content => $tx->res->body);
-}
-
-sub _log { shift->ua->server->app->log }
-
-sub _url2path {
-  my ($self, $url, $format) = @_;
-  my $query = $url->query->to_string;
-  my @path;
-
-  push @path, $url->host;
-  push @path, @{$url->path};
-
-  $query =~ s!\W!_!g;
-  $path[-1] .= "_$query.$format" if $query;
-
-  return CACHE_DIR, @path;
 }
 
 1;
@@ -455,28 +398,36 @@ delete the files on disk to download a new version.
 
   $bool = $self->load($asset, \%attrs);
 
-Used to load an existing asset from disk. C<%attrs> will override the
-way an asset is looked up. The example below will ignore
-L<minified|Mojolicious::Plugin::AssetPack::Asset/minified> and rather use
-the value from C<%attrs>:
+Used to load content from an existing asset from disk. C<%attrs> will
+override the way an asset is looked up. The cached file will look something
+like this:
 
-  $bool = $self->load($asset, {minified => $bool});
+  cache/${basename}-${checksum}.${key}.${format}
 
-=head2 persist
+Note that the C<checksum> above is the checksum of
+L<Mojolicious::Plugin::AssetPack::Asset/url> and not the value from
+L<Mojolicious::Plugin::AssetPack::Asset/checksum>.
 
-  $self = $self->persist;
+If a cached asset exists then C<load()> will check if there is a checksum
+file stored on disk. If such a file exists, then C<load()> will check if the
+checksum matches the L<Mojolicious::Plugin::AssetPack::Asset/checksum> of
+C<$asset>. If the there is a checksum mismatch, then the cached asset will be
+discarded. Note: The checksum check will not be done, if the checksum file
+does not exist. The checksum files does not need to be tracked in revision
+control. To ignore the files, you can add the line below to C<.gitignore>:
 
-Used to save the internal state of the store to disk.
-
-This method is EXPERIMENTAL, and may change without warning.
+  cache/.*.meta
 
 =head2 save
 
   $bool = $self->save($asset, \$content, \%attrs);
 
-Used to save C<$content> to asset to disk. C<%attrs> are usually the same as
+Used to save C<$content> for C<$asset> to disk. C<%attrs> are usually the same as
 L<Mojolicious::Plugin::AssetPack::Asset/TO_JSON> and used to document metadata
 about the C<$asset> so it can be looked up using L</load>.
+
+A checksum file will also be created if possible. This checksum will later be
+used by L</load> to check if there have been any changes in the input files.
 
 =head2 serve_asset
 

--- a/lib/Mojolicious/Plugin/AssetPack/Store.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Store.pm
@@ -69,9 +69,7 @@ sub asset {
 }
 
 sub load {
-  my $self  = shift;
-  my $asset = UNIVERSAL::isa($_[0], 'Mojolicious::Plugin::AssetPack::Asset') ? shift : undef;
-  my $attrs = shift;
+  my ($self, $asset, $attrs) = @_;
 
   my $cached = $self->asset(join '/', $self->_cache_path_parts_from_attrs($attrs));
   return undef unless $cached;
@@ -84,22 +82,19 @@ sub load {
 }
 
 sub save {
-  my $self  = shift;
-  my $asset = UNIVERSAL::isa($_[0], 'Mojolicious::Plugin::AssetPack::Asset') ? shift : $self->asset_class->new;
-  my $ref   = shift;
-  my $attrs = shift;
-  my $path  = path($self->paths->[0], $self->_cache_path_parts_from_attrs($attrs));
-  my $dir   = $path->dirname;
+  my ($self, $asset, $content, $attrs) = @_;
+  my $path = path($self->paths->[0], $self->_cache_path_parts_from_attrs($attrs));
+  my $dir = $path->dirname;
 
   mkdir $dir if !-d $dir and -w $dir->dirname;    # Do not care if this fail
   diag 'Save "%s" = %s', $path, -d $dir ? 1 : 0 if DEBUG;
 
   if (-w $dir) {
-    $asset->path($path->spurt($$ref));
+    $asset->path($path->spurt($$content));
     $self->_cached_checksum($asset => $asset->checksum);
   }
   else {
-    $asset->content($$ref);
+    $asset->content($$content);
   }
 
   map { defined $attrs->{$_} and $asset->$_($attrs->{$_}) } qw(format minified);

--- a/t/Helper.pm
+++ b/t/Helper.pm
@@ -27,8 +27,6 @@ unless ($ENV{TEST_KEEP_FILES}) {
 }
 
 sub cleanup {
-  $CREATED_FILES{path($ENV{TEST_HOME}, 'assets', $ENV{MOJO_ASSETPACK_DB_FILE})} = 1
-    if $ENV{MOJO_ASSETPACK_DB_FILE} and !$ENV{TEST_KEEP_FILES};
   unlink $_ for keys %CREATED_FILES;
 }
 
@@ -37,7 +35,6 @@ sub t {
   my $args  = ref $_[0] ? shift : {@_};
   my $app   = Mojolicious->new;
 
-  $ENV{MOJO_ASSETPACK_DB_FILE} = sprintf '%s.db', path($0)->basename;
   $class->cleanup unless state $cleaned_up++;
   ${$app->home} = $ENV{TEST_HOME};
   delete $app->log->{$_} for qw(handle path);

--- a/t/coffee.t
+++ b/t/coffee.t
@@ -7,7 +7,15 @@ $t->app->asset->process('app.js' => 'foo.coffee');
 $t->get_ok('/')->status_is(200)->element_exists(qq(script[src="/asset/e4c4b04389/foo.js"]));
 
 $t->get_ok($t->tx->res->dom->at('script')->{src})->status_is(200)
-  ->content_like(qr{console.log\('hello from foo coffee'\)});
+  ->content_like(qr{\sconsole.log\('hello from foo coffee'\)});
+
+$ENV{MOJO_MODE} = 'test_minify_from_here';
+$t = t::Helper->t(pipes => [qw(CoffeeScript JavaScript)]);
+Mojo::Util::monkey_patch('Mojolicious::Plugin::AssetPack::Pipe::CoffeeScript', run => sub { die 'Not cached!' });
+$t->app->asset->process('app.js' => 'foo.coffee');
+$t->get_ok('/')->status_is(200)->element_exists(qq(script[src="/asset/e4c4b04389/foo.js"]));
+$t->get_ok($t->tx->res->dom->at('script')->{src})->status_is(200)
+  ->content_like(qr/\{console.log\('hello from foo coffee'\)/);
 
 done_testing;
 

--- a/t/css.t
+++ b/t/css.t
@@ -12,7 +12,7 @@ $t->get_ok('/')->status_is(200)->element_exists(qq(link[href="/asset/d508287fc7/
 
 $t->get_ok($t->tx->res->dom->at('link')->{href})->status_is(200)->content_like(qr{aaa});
 
-$ENV{MOJO_MODE} = 'Test_minify_from_here';
+$ENV{MOJO_MODE} = 'test_minify_from_here';
 my @assets       = qw(d/x.css d/y.css d/already-min.css);
 my $url_checksum = checksum 'd/x.css';
 

--- a/t/google-font.t
+++ b/t/google-font.t
@@ -21,11 +21,6 @@ $t2->get_ok('/');
 $t2->get_ok($t2->tx->res->dom->at('link')->{href})->status_is(200)->header_is('Content-Type', 'text/css')
   ->content_like(qr{font-family:\W*Roboto});
 
-my $t3 = t::Helper->t(pipes => [qw(Css Fetch)]);
-
-is_deeply($t2->app->asset->store->_db, {}, 'nothing stored in db file (t2)');
-is_deeply($t3->app->asset->store->_db, {}, 'nothing stored in db file (t3)');
-
 done_testing;
 
 __DATA__

--- a/t/lazy.t
+++ b/t/lazy.t
@@ -27,9 +27,6 @@ $t->get_ok('/')->status_is(200)->element_exists(qq(link[href="/asset/5660087922/
 
 $t->get_ok('/asset/0dfb452e32/sass-two.css')->status_is(200)->content_like(qr{body\W+background:\s*black}s);
 
-$t = t::Helper->t(pipes => [qw(Css Fetch)]);
-is_deeply($t->app->asset->store->_db, {}, 'nothing was stored in db');
-
 done_testing;
 
 __DATA__

--- a/t/mount.t
+++ b/t/mount.t
@@ -1,8 +1,7 @@
 use lib '.';
 use t::Helper;
 
-$ENV{MOJO_MODE}              = 'development';
-$ENV{MOJO_ASSETPACK_DB_FILE} = 'mount.db';
+$ENV{MOJO_MODE} = 'development';
 
 my $app = Mojolicious->new;
 $app->plugin(AssetPack => {pipes => [qw(Css Combine)]});

--- a/t/recreate.t
+++ b/t/recreate.t
@@ -21,13 +21,13 @@ $t->app->asset->process('app.css' => @assets);
 $t->get_ok('/')->status_is(200)->element_exists(qq(link[href\$="/app.css"]));
 my $link = $t->tx->res->dom->at('link')->{href};
 
-# use cached
+diag 'use cached';
 $t = t::Helper->t(pipes => [qw(Css Combine)]);
 $t->app->asset->process('app.css' => @assets);
 $t->get_ok('/')->status_is(200);
 is $t->tx->res->dom->at('link')->{href}, $link, 'same link href';
 
-# recreate
+diag 'recreate';
 $recreate->spurt(".recreate { color: #bbb }\n");
 my $tr = t::Helper->t(pipes => [qw(Css Combine)]);
 $tr->app->asset->process('app.css' => @assets);
@@ -35,7 +35,7 @@ $tr->get_ok('/')->status_is(200);
 isnt $tr->tx->res->dom->at('link')->{href}, $link, 'changed link href';
 $tr->get_ok($tr->tx->res->dom->at('link')->{href})->status_is(200)->content_like(qr{color:\#bbb});
 
-# reset asset
+diag 'reset asset';
 $recreate->spurt(".recreate { color: #aaa }\n");
 
 done_testing;

--- a/t/riotjs.t
+++ b/t/riotjs.t
@@ -11,7 +11,7 @@ $t->get_ok('/')->status_is(200)->element_exists(qq(script[src="/asset/7373328564
 $t->get_ok($t->tx->res->dom->at('script')->{src})->status_is(200)
   ->content_like(qr{^\s*riot\.tag.*onclick=.*"foo";\n\s+this\.clicked.*\);\s*}s);
 
-$ENV{MOJO_MODE} = 'Test_minify_from_here';
+$ENV{MOJO_MODE} = 'test_minify_from_here';
 $t = t::Helper->t(pipes => [qw(Riotjs JavaScript)]);
 $t->app->asset->process('app.js' => ('r1.tag'));
 $t->get_ok('/')->status_is(200)->element_exists(qq(script[src="/asset/7373328564/r1.js"]));

--- a/t/rollup.t
+++ b/t/rollup.t
@@ -9,7 +9,7 @@ $t->get_ok('/')->status_is(200)->element_exists(qq(script[src="/asset/693887ef13
 $t->get_ok($t->tx->res->dom->at('script')->{src})->status_is(200)->content_like(qr{someLib\s=\sfunction});
 
 # Production mode
-$ENV{MOJO_MODE} = 'Test_minify_from_here';
+$ENV{MOJO_MODE} = 'test_minify_from_here';
 $t = t::Helper->t(pipes => [qw(RollupJs Combine)]);
 $t->app->asset->process('app.js' => 'js/some-lib.js');
 $t->get_ok('/')->status_is(200)->element_exists(qq(script[src="/asset/96b3f18ab2/app.js"]));

--- a/t/sass-bin.t
+++ b/t/sass-bin.t
@@ -16,7 +16,7 @@ $t->get_ok($html->at('link:nth-of-child(1)')->{href})->status_is(200)->content_l
 
 $t->get_ok($html->at('link:nth-of-child(2)')->{href})->status_is(200)->content_like(qr{footer.*\#aaa.*body.*\#222}s);
 
-$ENV{MOJO_MODE} = 'Test_minify_from_here';
+$ENV{MOJO_MODE} = 'test_minify_from_here';
 $t = t::Helper->t(pipes => [qw(Sass Css Combine)]);
 $t->app->asset->pipe('Sass')->{has_module} = '';    # make sure CSS::Sass is not used
 $t->app->asset->process('app.css' => ('sass.sass', 'sass/sass-1.scss'));

--- a/t/sass-source-map.t
+++ b/t/sass-source-map.t
@@ -1,7 +1,7 @@
 use lib '.';
 use t::Helper;
 plan skip_all => 'cpanm CSS::Sass' unless eval 'use CSS::Sass 3.3.0;1';
-plan skip_all => 'cpanm CSS::Sass' unless $ENV{TEST_SOURCE_MAPS};
+plan skip_all => 'TEST_SOURCE_MAPS=1' unless $ENV{TEST_SOURCE_MAPS} or -e '.test-everything';
 
 my $t = t::Helper->t(pipes => [qw(Sass)]);
 $t->app->asset->process('app.css' => 'sass/sass-1.scss');

--- a/t/sass.t
+++ b/t/sass.t
@@ -14,7 +14,7 @@ $t->get_ok($html->at('link:nth-of-child(2)')->{href})->status_is(200)
 
 $ENV{MOJO_MODE} = 'Test_minify_from_here';
 
-# Assets from __DATA__
+note 'Assets from __DATA__';
 $t = t::Helper->t(pipes => [qw(Sass Css Combine)]);
 $t->app->asset->process('app.css' => ('sass-one.sass', 'sass-two.scss'));
 $t->get_ok('/')->status_is(200)->element_exists(qq(link[href="/asset/08eb78e42a/app.css"]));
@@ -27,17 +27,17 @@ if (-e '.test-everything') {
   is $content[1], 'body{background:#fff}.scss{color:#aaa}.scss .nested{color:#939393}', 'line2';
 }
 
-Mojo::Util::monkey_patch('CSS::Sass', sass2scss => sub { die 'Nope!' });
+Mojo::Util::monkey_patch('CSS::Sass', sass2scss => sub { die 'sass2scss() will not be called' });
 $t = t::Helper->t(pipes => [qw(Sass Css Combine)]);
 ok eval { $t->app->asset->process('app.css' => ('sass-one.sass', 'sass-two.scss')) }, 'using cached assets' or diag $@;
 
-# Assets from disk
+note 'Assets from disk';
 $t = t::Helper->t(pipes => [qw(Sass Css Combine)]);
 $t->app->asset->process('app.css' => 'sass/sass-1.scss');
 $t->get_ok('/')->status_is(200)->element_exists(qq(link[href="/asset/4abbb4a8c8/app.css"]));
 $t->get_ok($t->tx->res->dom->at('link')->{href})->status_is(200)->content_like(qr{footer.*\#aaa.*body.*\#222}s);
 
-# Duplicate @import
+note 'Duplicate @import';
 $t = t::Helper->t(pipes => [qw(Sass Css Combine)]);
 ok eval { $t->app->asset->process('dup.css' => 'sass/sass-2-dup.scss') }, 'sass with duplicate @imports' or diag $@;
 

--- a/t/sass.t
+++ b/t/sass.t
@@ -12,7 +12,7 @@ $t->get_ok($html->at('link:nth-of-child(1)')->{href})->status_is(200)->content_l
 $t->get_ok($html->at('link:nth-of-child(2)')->{href})->status_is(200)
   ->content_like(qr{body\W+background:.*\.scss \.nested\W+color:\s+\#9\d9\d9\d}s);
 
-$ENV{MOJO_MODE} = 'Test_minify_from_here';
+$ENV{MOJO_MODE} = 'test_minify_from_here';
 
 note 'Assets from __DATA__';
 $t = t::Helper->t(pipes => [qw(Sass Css Combine)]);


### PR DESCRIPTION
This PR will break backcompat with the existing version of AssetPack. Here are the changes:

* Some cached assets need to be recalculated
* `$asset->checksum` need to be calculated in the `before_process` process step
* `$asset->FROM_JSON` is removed
* `$store->load` has a new API
* `$store->save` has a new API

More about the replacement of `assetpack.db`:
* One meta file will be created for each topic, instead of tracking them inside a common `assetpack.db` file
* The meta files can be ignored by revision control (optional)
* `$store->load` will load cached assets, even if there is no checksum file