### PR TITLE
Match documentation of ->processed with code

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack.pm
+++ b/lib/Mojolicious/Plugin/AssetPack.pm
@@ -335,8 +335,7 @@ C<$definition_file> defaults to "assetpack.def".
   $collection = $self->processed($topic);
 
 Can be used to retrieve a L<Mojo::Collection> object, with zero or more
-L<Mojolicious::Plugin::AssetPack::Asset> objects. Returns undef if C<$topic> is
-not defined with L</process>.
+L<Mojolicious::Plugin::AssetPack::Asset> objects.
 
 =head2 register
 


### PR DESCRIPTION
When topic is not defined we return an empty Mojo::Collection,
as already documented, so we don't need to mention the
erroneous `undef` portion.

```
$ cpanm Mojolicious Mojolicious::Plugin::AssetPack
Mojolicious is up to date. (8.61)
Mojolicious::Plugin::AssetPack is up to date. (2.09)


$ perl -MMojolicious::Lite -wlE 'plugin "AssetPack"; my $res = app->asset->processed("meow.js"); say $res; say $res->size'
Mojo::Collection=ARRAY(0xaace1e0)
0
```