### PR TITLE
Update code to avoid use of DEPRECATED Mojolicious methods

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack.pm
+++ b/lib/Mojolicious/Plugin/AssetPack.pm
@@ -11,7 +11,7 @@ our $VERSION = '2.09';
 has minify => sub { shift->_app->mode eq 'development' ? 0 : 1 };
 
 has route => sub {
-  shift->_app->routes->route('/asset/:checksum/*name')->via(qw(HEAD GET))->name('assetpack')->to(cb => \&_serve);
+  shift->_app->routes->any([qw(HEAD GET)] => '/asset/:checksum/*name')->name('assetpack')->to(cb => \&_serve);
 };
 
 has store => sub {

--- a/t/mount.t
+++ b/t/mount.t
@@ -10,7 +10,7 @@ $app->asset->process;
 $app->routes->get('/' => 'index');
 
 my $t = Test::Mojo->new(Mojolicious->new);
-$t->app->routes->route('/mounted')->detour(app => $app);
+$t->app->routes->any('/mounted')->detour(app => $app);
 $t->get_ok('/')->status_is(404);
 $t->get_ok('/mounted')->status_is(200)->element_exists('link[href="/mounted/asset/5524d15cbb/foo.css"]');
 $t->get_ok($t->tx->res->dom->at('link')->{href})->status_is(200);


### PR DESCRIPTION
Fixes warnings issued by latest Mojolicious:
```
Mojolicious::Routes::Route::route is DEPRECATED in favor of Mojolicious::Routes::Route::any at /home/zoffix/perl5/perlbrew/perls/perl-5.32.0/lib/site_perl/5.32.0/Mojolicious/Plugin/AssetPack.pm line 14.
Mojolicious::Routes::Route::via is DEPRECATED in favor of Mojolicious::Routes::Route::methods at /home/zoffix/perl5/perlbrew/perls/perl-5.32.0/lib/site_perl/5.32.0/Mojolicious/Plugin/AssetPack.pm line 14.
```

Passes `TEST_ONLINE=1 make test`

Note: [`t/mount.t`](https://github.com/jhthorsen/mojolicious-plugin-assetpack/pull/142/files#diff-f9081d531dc02ab68c96fd80008289bebbc4fac63b9db5defa464ec27bbe7b98R13) still has deprecation warnings about `->detour` used in that test file. I'm unsure how to fix it. I tried `$t->app->routes->any('/mounted' => {app => $app});` on that line, but test failed.