### PR TITLE
t: Use 'partial(1)->to' instead of 'detour' which was deprecated in Mojolicious 9

### DIFF
--- a/t/mount.t
+++ b/t/mount.t
@@ -10,7 +10,7 @@ $app->asset->process;
 $app->routes->get('/' => 'index');
 
 my $t = Test::Mojo->new(Mojolicious->new);
-$t->app->routes->any('/mounted')->detour(app => $app);
+$t->app->routes->any('/mounted')->partial(1)->to(app => $app);
 $t->get_ok('/')->status_is(404);
 $t->get_ok('/mounted')->status_is(200)->element_exists('link[href="/mounted/asset/5524d15cbb/foo.css"]');
 $t->get_ok($t->tx->res->dom->at('link')->{href})->status_is(200);


### PR DESCRIPTION
Fixes https://github.com/jhthorsen/mojolicious-plugin-assetpack/issues/143