### PR TITLE
Call sass with --trace

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
@@ -61,7 +61,7 @@ sub process {
       $asset->content($store->save(\$css, $attrs))->FROM_JSON($attrs);
     }
     else {
-      my @args = (qw(sass -s), map { ('-I', $_) } @{$opts{include_paths}});
+      my @args = (qw(sass -s --trace), map { ('-I', $_) } @{$opts{include_paths}});
       push @args, '--scss'          if $asset->format eq 'scss';
       push @args, qw(-t compressed) if $attrs->{minified};
       $self->run(\@args, \$content, \my $css, undef);


### PR DESCRIPTION
### Summary

Call `sass` with the `--trace` option to get a backtrace in case of an error.

### Motivation

Sometimes there are errors like this:

    TypeError: String can't be coerced into Integer
      Use --trace for backtrace.

The input is not logged, and not even the line number & file. Hard to debug when the error is not easily reproducible.


### References
* https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/180