### PR TITLE
Propagate errors from sass compiler

### DIFF
--- a/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
+++ b/lib/Mojolicious/Plugin/AssetPack/Pipe/Sass.pm
@@ -64,7 +64,11 @@ sub process {
       my @args = (qw(sass -s), map { ('-I', $_) } @{$opts{include_paths}});
       push @args, '--scss'          if $asset->format eq 'scss';
       push @args, qw(-t compressed) if $attrs->{minified};
-      $self->run(\@args, \$content, \my $css, undef);
+      $self->run(\@args, \$content, \my $css, \my $err);
+      my $exit = $? > 0 ? $? >> 8 : $?;
+      if ($exit) {
+        die sprintf '[Pipe::Sass] Could not compile "%s" with opts=%s: %s', $asset->url, dumper(\%opts), $err;
+      }
       $asset->content($store->save(\$css, $attrs))->FROM_JSON($attrs);
     }
   });


### PR DESCRIPTION
### Summary
Compiling invalid sass files with CSS:Sass dies, it should fail as well without using the module, i.e. with sass binary.

### Motivation
AssetPack is ignoring relevant errors which can result into a successful build while the are actually missing assets 